### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Python and Flask.
 Resources
 ---------
 
-- `Documentation <http://flask-split.readthedocs.org/>`_
+- `Documentation <https://flask-split.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/jpvanhal/flask-split/issues>`_
 - `Code <http://github.com/jpvanhal/flask-split/>`_
 - `Development Version

--- a/flask_split/templates/split/index.html
+++ b/flask_split/templates/split/index.html
@@ -49,6 +49,6 @@
     </div>
   {% else %}
     <p class="lead">No experiments have been started yet. You need to define them in your code and introduce them to your users.</p>
-    <p class="lead">Check out <a href="http://flask-split.rtfd.org/">the documentation</a> for more help getting started.</p>
+    <p class="lead">Check out <a href="https://flask-split.readthedocs.io/">the documentation</a> for more help getting started.</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.