### PR TITLE
Python 2 -> Python 3 compatability fixes

### DIFF
--- a/flask_split/core.py
+++ b/flask_split/core.py
@@ -181,7 +181,7 @@ def _doing_other_tests(experiment_key):
     experiment with the key ``experiment_key`` at the moment, or `False`
     otherwise.
     """
-    for key in _get_session().iterkeys():
+    for key in _get_session():
         if key != experiment_key:
             return True
     return False
@@ -196,7 +196,7 @@ def _clean_old_versions(experiment):
 def _old_versions(experiment):
     if experiment.version > 0:
         return [
-            key for key in _get_session().iterkeys()
+            key for key in _get_session()
             if key.startswith(experiment.name) and key != experiment.key
         ]
     else:

--- a/flask_split/templates/split/base.html
+++ b/flask_split/templates/split/base.html
@@ -3,25 +3,25 @@
 <head>
   <meta charset="utf-8">
   <title>Flask-Split</title>
-  <link rel="stylesheet" href="{{ url_for('.static', filename='css/bootstrap.min.css') }}">
-  <link rel="stylesheet" href="{{ url_for('.static', filename='css/dashboard.css') }}">
+  <link rel="stylesheet" href="{{ url_for('split.static', filename='css/bootstrap.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('split.static', filename='css/dashboard.css') }}">
 </head>
 <body>
-  <div class="navbar">
-    <div class="navbar-inner">
-      <div class="container">
-        <a class="brand" href="{{ url_for('.index') }}">Flask-Split Dashboard</a>
-      </div>
+    <div class="navbar">
+        <div class="navbar-inner">
+            <div class="container">
+                <a class="brand" href="{{ url_for('.index') }}">Flask-Split Dashboard</a>
+            </div>
+        </div>
     </div>
-  </div>
-  <div class="container">
-    {% block content %}{% endblock %}
-    <div id="footer">
-      <p>Powered by <a href="https://github.com/jpvanhal/flask-split">Flask-Split</a> v{{ version }}</p>
+    <div class="container">
+        {% block content %}{% endblock %}
+        <div id="footer">
+            <p>Powered by <a href="https://github.com/jpvanhal/flask-split">Flask-Split</a> v{{ version }}</p>
+        </div>
     </div>
-  </div>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-  <script src="{{ url_for('.static', filename='js/bootstrap.min.js') }}"></script>
-  <script src="{{ url_for('.static', filename='js/dashboard.js') }}"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="{{ url_for('split.static', filename='js/bootstrap.min.js') }}"></script>
+    <script src="{{ url_for('split.static', filename='js/dashboard.js') }}"></script>
 </body>
 </html>

--- a/flask_split/templates/split/base.html
+++ b/flask_split/templates/split/base.html
@@ -20,7 +20,7 @@
             <p>Powered by <a href="https://github.com/jpvanhal/flask-split">Flask-Split</a> v{{ version }}</p>
         </div>
     </div>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="{{ url_for('split.static', filename='js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('split.static', filename='js/dashboard.js') }}"></script>
 </body>

--- a/flask_split/utils.py
+++ b/flask_split/utils.py
@@ -9,7 +9,10 @@
     :license: MIT, see LICENSE for more details.
 """
 
-import urlparse
+try:
+    import urllib.parse as urlparse
+except ImportError:
+    import urlparse
 
 from flask import current_app
 import redis
@@ -28,4 +31,4 @@ def _get_redis_connection():
     :return: an instance of :class:`redis.Connection`
     """
     url = current_app.config.get('REDIS_URL', 'redis://localhost:6379')
-    return redis.from_url(url)
+    return redis.from_url(url, decode_responses=True)

--- a/flask_split/views.py
+++ b/flask_split/views.py
@@ -25,12 +25,6 @@ split = Blueprint('split', 'flask.ext.split',
 )
 
 
-@split.context_processor
-def inject_version():
-    from . import __version__
-    return dict(version=__version__)
-
-
 @split.route('/')
 def index():
     """Render a dashboard that lists all active experiments."""


### PR DESCRIPTION
Flask_Split should now support both Python 2 and Python 3.

This will introduce a minor performance hit on Py2 as the iterators `iterkeys` are no-longer used (on Py3 these will be used).

Additionally the correct `urlparse` for Py2 and `urllib.parse` will be imported based on a caught `ImportError`.

The Redis-Py class instance is also started with the arg `decode_responses=True`, to ensure `str`s are passed rather than `bytes` in Python 3. For Python 2 this will return `unicode` strings - I don't currently have a Python 2 Flask app to play with to check this hasn't broken anything, but from a quick check in Python 2 `str(unicode('asdf')) == 'asdf'`